### PR TITLE
Improved export function in sounding.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 CHANGELOG
 =========
 
+0.0.8 (2025-06-05)
+------------------
+* Improved version of export function which sanitizes the platform name and ensures more robust output. (:pr:`44`) `Marius Winkler`_.
+
 0.0.7 (2024-09-24)
 ------------------
 * Clean-release with GitHub and pypi release (:pr:`39`) `Hauke Schulz`_.

--- a/pysonde/sounding.py
+++ b/pysonde/sounding.py
@@ -405,14 +405,13 @@ class Sounding:
         """
         Saves sounding to disk with correctly formatted filename.
 
-        - Uses platform from `cfg.main.get("platform")` instead of extracting from filename.
-        - Converts "RV Meteor" → "RV_Meteor" while keeping config unchanged.
-        - Ensures 'platform' variable is correctly set before exporting.
+        - Uses platform from `cfg.main.get("platform")`
+        - Changes platform name to snake_format.
         """
+        platform_name = cfg.main.get("platform").replace(" ", "_")
+
         output = output_fmt.format(
-            platform=cfg.main.get("platform").replace(
-                " ", "_"
-            ),  # Replace spaces with underscores
+            platform=platform_name,
             campaign=cfg.main.get("campaign"),
             campaign_id=cfg.main.get("campaign_id"),
             direction=self.meta_data["sounding_direction"],
@@ -422,7 +421,6 @@ class Sounding:
         directory = os.path.dirname(output)
         Path(directory).mkdir(parents=True, exist_ok=True)
 
-        platform_name = cfg.main.get("platform").replace(" ", "_")
         platform_data = [platform_name] * self.dataset.dims["sounding"]
         self.dataset["platform"] = xr.DataArray(platform_data, dims=["sounding"])
         self.dataset["platform"].attrs["long_name"] = "Launching platform"

--- a/pysonde/sounding.py
+++ b/pysonde/sounding.py
@@ -403,7 +403,7 @@ class Sounding:
 
     def export(self, output_fmt, cfg):
         """
-        Saves sounding to disk with correctly formatted filename.
+        Save sounding to disk.
 
         - Uses platform from `cfg.main.get("platform")`
         - Changes platform name to snake_format.


### PR DESCRIPTION
- Uses platform from `cfg.main.get("platform")` instead of extracting from filename.
- Converts "RV Meteor" → "RV_Meteor" while keeping config unchanged.
- Ensures 'platform' variable is correctly set before exporting.